### PR TITLE
feat: verification email

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "PORT=5173 next dev ",
+    "dev": "set PORT=5173 && next dev ",
     "build": "next build",
     "lint": "next lint",
     "mock": "node ./mock/index.js",

--- a/src/app/(auth)/login/_components/LogInForm.tsx
+++ b/src/app/(auth)/login/_components/LogInForm.tsx
@@ -5,6 +5,7 @@ import { useForm, Controller } from 'react-hook-form';
 import AccountOutlineIcon from 'mdi-react/AccountOutlineIcon';
 import { Alert } from 'react-bootstrap';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import PasswordField from '@/shared/components/form/Password';
 import {
   FormGroup,
@@ -35,6 +36,10 @@ const LogInForm = ({ onSubmit, error = '' }: LogInFormProps) => {
     formState: { errors },
   } = useForm();
   const rememberMe = watch('rememberMe');
+  const router = useRouter();
+  const handleRegisterButtonClick = () => {
+    router.push('/register');
+  };
 
   useEffect(() => {
     if (rememberMe !== undefined && typeof window !== 'undefined') {
@@ -122,8 +127,8 @@ const LogInForm = ({ onSubmit, error = '' }: LogInFormProps) => {
       <AccountButton variant="primary" type="submit">
         Sign In
       </AccountButton>
-      <AccountButton variant="outline-primary" to="/register">
-        <Link href="register">Create Account</Link>
+      <AccountButton onClick={handleRegisterButtonClick} variant="outline-primary">
+        Create Account
       </AccountButton>
     </LoginForm>
   );

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -21,6 +21,7 @@ import { USER_LOGIN } from '@/graphql/auth';
 import { AUTH_TOKEN, EMAIL } from '@/shared/constants/storage';
 import { useSearchParams } from '@/hooks/useSearchParams';
 import { useRouter } from 'next/navigation';
+import Loading from '@/shared/components/Loading';
 import LogInForm from './_components/LogInForm';
 
 const Login = () => {
@@ -28,8 +29,10 @@ const Login = () => {
   const [error, setError] = useState('');
   const originUrl = useSearchParams().get('orgUrl');
   const [login] = useMutation(USER_LOGIN);
+  const [isLoading, setIsLoading] = useState(false);
 
   const onSubmit = async (data: { email: string; password: string; remember_me: boolean }) => {
+    setIsLoading(true);
     const result = await login({
       variables: data,
     });
@@ -56,42 +59,47 @@ const Login = () => {
     } else {
       // for login failed
       setError(`Login failed: ${result.data.login.message}`);
+      setIsLoading(false);
     }
   };
 
   return (
     <AccountWrap>
-      <AccountContent>
-        <AccountCard>
-          <AccountHead>
-            <AccountTitle>
-              Welcome to
-              <br />
-              <AccountLogo>
-                BeeQuant
-                <AccountLogoAccent> AI</AccountLogoAccent>
-              </AccountLogo>
-            </AccountTitle>
-            <h4 className="subhead">Trading smart, trading with BeeQuant AI</h4>
-          </AccountHead>
-          <LogInForm onSubmit={onSubmit} error={error} />
-          <AccountOr>
-            <p>Or Easily Using</p>
-          </AccountOr>
-          <AccountSocial>
-            {/* @ts-ignore - Ignoring because of complex union types incorrectly inferred */}
-            <AccountSocialButtonFacebook
-              className="account__social-btn account__social-btn--facebook"
-              to="/login"
-            >
-              <FacebookIcon />
-            </AccountSocialButtonFacebook>
-            <AccountSocialButtonGoogle to="/login">
-              <GooglePlusIcon />
-            </AccountSocialButtonGoogle>
-          </AccountSocial>
-        </AccountCard>
-      </AccountContent>
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <AccountContent>
+          <AccountCard>
+            <AccountHead>
+              <AccountTitle>
+                Welcome to
+                <br />
+                <AccountLogo>
+                  BeeQuant
+                  <AccountLogoAccent> AI</AccountLogoAccent>
+                </AccountLogo>
+              </AccountTitle>
+              <h4 className="subhead">Trading smart, trading with BeeQuant AI</h4>
+            </AccountHead>
+            <LogInForm onSubmit={onSubmit} error={error} />
+            <AccountOr>
+              <p>Or Easily Using</p>
+            </AccountOr>
+            <AccountSocial>
+              {/* @ts-ignore - Ignoring because of complex union types incorrectly inferred */}
+              <AccountSocialButtonFacebook
+                className="account__social-btn account__social-btn--facebook"
+                to="/login"
+              >
+                <FacebookIcon />
+              </AccountSocialButtonFacebook>
+              <AccountSocialButtonGoogle to="/login">
+                <GooglePlusIcon />
+              </AccountSocialButtonGoogle>
+            </AccountSocial>
+          </AccountCard>
+        </AccountContent>
+      )}
     </AccountWrap>
   );
 };

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -15,11 +15,13 @@ import { useMutation } from '@apollo/client';
 import { USER_REGISTER } from '@/graphql/auth';
 import { useTitle } from '@/hooks/useTitle';
 import Link from 'next/link';
+import Loading from '@/shared/components/Loading';
 import RegisterForm from './_components/RegisterForm';
 import RegisterSuccess from './_components/RegisterSuccess';
 
 const Register = () => {
   const [register] = useMutation(USER_REGISTER);
+  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [isRegistered, setIsRegistered] = useState(false);
 
@@ -31,6 +33,7 @@ const Register = () => {
     displayName: string;
     ref: string;
   }) => {
+    setIsLoading(true);
     const result = await register({
       variables: {
         input: data,
@@ -39,13 +42,19 @@ const Register = () => {
 
     if (result.data.register.code === 200) {
       setIsRegistered(true);
+      setIsLoading(false);
     }
     // for register failed
     setError(`Register failed: ${result.data.register.message}`);
+    setIsLoading(false);
   };
 
   if (isRegistered) {
     return <RegisterSuccess />;
+  }
+
+  if (isLoading) {
+    return <Loading />;
   }
 
   return (

--- a/src/app/verify-email/_components/VerifyFail.test.tsx
+++ b/src/app/verify-email/_components/VerifyFail.test.tsx
@@ -1,0 +1,71 @@
+import { screen, render, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { useRouter } from 'next/navigation';
+import VerifyFail from './VerifyFail';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+interface MockAppRouterInstance {
+  push: jest.Mock;
+  back?: jest.Mock;
+  forward?: jest.Mock;
+  refresh?: jest.Mock;
+  replace?: jest.Mock;
+  prefetch?: jest.Mock;
+}
+
+describe('VerifyFail component', () => {
+  it('should render successfully and show verification failed message', () => {
+    render(
+      <Router>
+        <VerifyFail error="Link expired" />
+      </Router>
+    );
+
+    const errorMessage = screen.getByText(/Link expired/i);
+    expect(errorMessage).toBeInTheDocument();
+
+    const titleMessage = screen.getByText(/Verification failed/i);
+    expect(titleMessage).toBeInTheDocument();
+  });
+
+  it('should render image', () => {
+    render(
+      <Router>
+        <VerifyFail error="Invalid verification token" />
+      </Router>
+    );
+    const image = screen.getByAltText('404');
+    expect(image).toBeInTheDocument();
+  });
+
+  it('triggers router push on button click', async () => {
+    const pushMock = jest.fn();
+
+    const mockRouterInstance: MockAppRouterInstance = {
+      push: pushMock,
+      back: jest.fn(),
+      forward: jest.fn(),
+      refresh: jest.fn(),
+      replace: jest.fn(),
+      prefetch: jest.fn(),
+    };
+
+    (useRouter as jest.MockedFunction<typeof useRouter>).mockReturnValue(
+      mockRouterInstance as unknown as ReturnType<typeof useRouter>
+    );
+
+    render(
+      <Router>
+        <VerifyFail error="Invalid verification token" />
+      </Router>
+    );
+
+    fireEvent.click(screen.getByText('Back to Login'));
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/login');
+    });
+  });
+});

--- a/src/app/verify-email/_components/VerifyFail.tsx
+++ b/src/app/verify-email/_components/VerifyFail.tsx
@@ -7,14 +7,14 @@ import {
   AccountContent,
   AccountHead,
   AccountLogo,
-  AccountLogoAccent,
+  AccountLogoError,
   AccountTitle,
   AccountWrap,
 } from '@/shared/components/account/AccountElements';
 
-const RegisterSuccess = () => {
+const VerifyFail = ({ error }: { error: string }) => {
   const router = useRouter();
-  const handleFinishedButtonClick = () => {
+  const handleBackToLoginButtonClick = () => {
     router.push('/login');
   };
 
@@ -22,24 +22,26 @@ const RegisterSuccess = () => {
     <AccountWrap>
       <AccountContent>
         <AccountCard>
-          <AccountImage src="img/success.png" alt="success" />
+          <AccountImage src="img/404.png" alt="404" />
           <AccountHead>
             <AccountTitle>
               <AccountLogo>
-                <AccountLogoAccent>
-                  Please check your mailbox
+                <AccountLogoError>
+                  Opps !
                   <br />
-                </AccountLogoAccent>
+                  Verification failed
+                  <br />
+                </AccountLogoError>
               </AccountLogo>
-              We have sent you a verification email
+              {error}
             </AccountTitle>
           </AccountHead>
           {/*
-           @ts-ignore
+          @ts-ignore
            - Ignoring because of complex union types that are not correctly inferred
            */}
-          <AccountButton onClick={handleFinishedButtonClick} variant="outline-primary">
-            Finished sign-up. Ready to trade
+          <AccountButton onClick={handleBackToLoginButtonClick} variant="outline-primary">
+            Back to Login
           </AccountButton>
         </AccountCard>
       </AccountContent>
@@ -47,7 +49,7 @@ const RegisterSuccess = () => {
   );
 };
 
-export default RegisterSuccess;
+export default VerifyFail;
 
 // region STYLES
 

--- a/src/app/verify-email/_components/VerifySuccess.test.tsx
+++ b/src/app/verify-email/_components/VerifySuccess.test.tsx
@@ -1,0 +1,65 @@
+import { screen, render, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { useRouter } from 'next/navigation';
+import VerifySuccess from './VerifySuccess';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('VerifySuccess component', () => {
+  it('should render successfully and show verification success message', () => {
+    render(
+      <Router>
+        <VerifySuccess />
+      </Router>
+    );
+
+    const titleMessage1 = screen.getByText(/Congratulations !/i);
+    expect(titleMessage1).toBeInTheDocument();
+
+    const titleMessage2 = screen.getByText(/Email Verified/i);
+    expect(titleMessage2).toBeInTheDocument();
+
+    const successMessage = screen.getByText(/Your registration is successful/i);
+    expect(successMessage).toBeInTheDocument();
+  });
+
+  it('should render image', () => {
+    render(
+      <Router>
+        <VerifySuccess />
+      </Router>
+    );
+    const image = screen.getByAltText('success');
+    expect(image).toBeInTheDocument();
+  });
+
+  it('triggers router push on button click', async () => {
+    const pushMock = jest.fn();
+
+    const mockRouterInstance = {
+      push: pushMock,
+      back: jest.fn(),
+      forward: jest.fn(),
+      refresh: jest.fn(),
+      replace: jest.fn(),
+      prefetch: jest.fn(),
+    };
+
+    (useRouter as jest.MockedFunction<typeof useRouter>).mockReturnValue(
+      mockRouterInstance as unknown as ReturnType<typeof useRouter>
+    );
+
+    render(
+      <Router>
+        <VerifySuccess />
+      </Router>
+    );
+
+    fireEvent.click(screen.getByText('Back to Login'));
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/login');
+    });
+  });
+});

--- a/src/app/verify-email/_components/VerifySuccess.tsx
+++ b/src/app/verify-email/_components/VerifySuccess.tsx
@@ -12,9 +12,9 @@ import {
   AccountWrap,
 } from '@/shared/components/account/AccountElements';
 
-const RegisterSuccess = () => {
+const VerifySuccess = () => {
   const router = useRouter();
-  const handleFinishedButtonClick = () => {
+  const handleBackToLoginButtonClick = () => {
     router.push('/login');
   };
 
@@ -27,19 +27,21 @@ const RegisterSuccess = () => {
             <AccountTitle>
               <AccountLogo>
                 <AccountLogoAccent>
-                  Please check your mailbox
+                  Congratulations !
+                  <br />
+                  Email Verified
                   <br />
                 </AccountLogoAccent>
               </AccountLogo>
-              We have sent you a verification email
+              Your registration is successful
             </AccountTitle>
           </AccountHead>
           {/*
-           @ts-ignore
+          @ts-ignore
            - Ignoring because of complex union types that are not correctly inferred
            */}
-          <AccountButton onClick={handleFinishedButtonClick} variant="outline-primary">
-            Finished sign-up. Ready to trade
+          <AccountButton onClick={handleBackToLoginButtonClick} variant="outline-primary">
+            Back to Login
           </AccountButton>
         </AccountCard>
       </AccountContent>
@@ -47,7 +49,7 @@ const RegisterSuccess = () => {
   );
 };
 
-export default RegisterSuccess;
+export default VerifySuccess;
 
 // region STYLES
 

--- a/src/app/verify-email/page.test.tsx
+++ b/src/app/verify-email/page.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+import { VERIFY_EMAIL } from '@/graphql/verifyEmail';
+import Page from './page';
+
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'),
+  useSearchParams: jest.fn(() => ({
+    get: jest.fn((key) => {
+      if (key === 'email') return 'test@example.com';
+      if (key === 'token') return 'testtoken123';
+      return null;
+    }),
+  })),
+  useRouter: jest.fn(),
+}));
+
+const mockMutationResult = (code: number) => ({
+  data: {
+    verifyEmail: {
+      code,
+      message: code === 200 ? 'Your registration is successful' : 'Verification failed',
+    },
+  },
+});
+
+describe('Email Verification Page', () => {
+  it('should render success message on successful email verification', async () => {
+    const mocks = [
+      {
+        request: {
+          query: VERIFY_EMAIL,
+          variables: {
+            email: 'test@example.com',
+            token: 'testtoken123',
+          },
+        },
+        result: mockMutationResult(200),
+      },
+    ];
+
+    const { getByText } = render(
+      <MockedProvider mocks={mocks}>
+        <Page />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByText('Your registration is successful')).toBeInTheDocument();
+    });
+  });
+
+  it('should render failure message on failed email verification', async () => {
+    const failMocks = [
+      {
+        request: {
+          query: VERIFY_EMAIL,
+          variables: {
+            email: 'test@example.com',
+            token: 'testtoken123',
+          },
+        },
+        result: mockMutationResult(10008),
+      },
+    ];
+    const { getByText } = render(
+      <MockedProvider mocks={failMocks}>
+        <Page />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByText('Verification failed')).toBeInTheDocument();
+    });
+  });
+
+  it('should render error message if an error occurs during verification', async () => {
+    const errorMocks = [
+      {
+        request: {
+          query: VERIFY_EMAIL,
+          variables: {
+            email: 'test@example.com',
+            token: 'testtoken123',
+          },
+        },
+        error: new Error('An error occurred'),
+      },
+    ];
+
+    const { getByText } = render(
+      <MockedProvider mocks={errorMocks}>
+        <Page />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByText('An error occurred')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState, useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { VERIFY_EMAIL } from '@/graphql/verifyEmail';
+import { useMutation } from '@apollo/client';
+import Loading from '@/shared/components/Loading';
+import VerifySuccess from './_components/VerifySuccess';
+import VerifyFail from './_components/VerifyFail';
+
+const Search = () => {
+  const searchParams = useSearchParams();
+  const email = searchParams.get('email');
+  const token = searchParams.get('token');
+  const [verifyEmail] = useMutation(VERIFY_EMAIL);
+  const [mutationError, setMutationError] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isVerified, setIsVerified] = useState(false);
+
+  useEffect(() => {
+    const fetchAndVerifyEmail = async () => {
+      try {
+        const result = await verifyEmail({
+          variables: {
+            email,
+            token,
+          },
+        });
+
+        if (result.data.verifyEmail.code === 200) {
+          setIsVerified(true);
+          setIsLoading(false);
+        } else {
+          setMutationError(`${result.data.verifyEmail.message}`);
+          setIsLoading(false);
+        }
+      } catch (e) {
+        setMutationError('An error occurred');
+        setIsLoading(false);
+      }
+    };
+
+    fetchAndVerifyEmail();
+  }, []);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (isVerified) {
+    return <VerifySuccess />;
+  }
+
+  return <VerifyFail error={mutationError} />;
+};
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Search />
+    </Suspense>
+  );
+}

--- a/src/graphql/verifyEmail.ts
+++ b/src/graphql/verifyEmail.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export const VERIFY_EMAIL = gql`
+  mutation VerifyEmail($email: String!, $token: String!) {
+    verifyEmail(email: $email, token: $token) {
+      code
+      message
+    }
+  }
+`;

--- a/src/hooks/userHooks.ts
+++ b/src/hooks/userHooks.ts
@@ -31,7 +31,12 @@ export const useLoadUser = () => {
           displayName,
           refetchHandler: refetch,
         });
-        if (pathName.match('/login') && typeof window !== 'undefined') {
+        if (
+          pathName.match('/login') &&
+          pathName.match('/register') &&
+          !pathName.match('/verify-email') &&
+          typeof window !== 'undefined'
+        ) {
           router.push('/dashboard');
         }
       }
@@ -41,7 +46,12 @@ export const useLoadUser = () => {
         refetchHandler: refetch,
       });
       console.error('failed retrieving user info, backing to login');
-      if (!pathName.match('/login') && typeof window !== 'undefined') {
+      if (
+        !pathName.match('/login') &&
+        !pathName.match('/register') &&
+        !pathName.match('/verify-email') &&
+        typeof window !== 'undefined'
+      ) {
         router.push(`/login?orgUrl=${pathName}`);
       }
     },

--- a/src/shared/components/account/AccountElements.tsx
+++ b/src/shared/components/account/AccountElements.tsx
@@ -8,6 +8,7 @@ import {
   colorBlueHover,
   colorDarkRed,
   colorDustyWhite,
+  colorLightRed,
   colorLightText,
   colorVeryLightRed,
   colorWhite,
@@ -71,6 +72,10 @@ export const AccountLogo = styled.span`
 
 export const AccountLogoAccent = styled.span`
   color: ${colorBlue};
+`;
+
+export const AccountLogoError = styled.span`
+  color: ${colorLightRed};
 `;
 
 export const AccountOr = styled.div`


### PR DESCRIPTION
Added (dynamic) email verification function
- When a user press Sign up button Then the system will verify the user email
- And upon successful verification of email, the system will give a notification of “We have sent you a verification email” and a “Finished sign-up. Ready to trade” button (direct to sign-in page)
- Verify through email link
- When a new user click on the verification link (”Verify now”) Then a user's account should be created
- And the system should direct to successful sign-up page
- And a sign-in button “Back to login” which will direct to sign-in page.
- fix AccountButton UI, for 'Create Account' and 'Back to Login' and 'Finished sign-up. Ready to trade'

Resolve CP 8


![2024-05-15 06_59_29-user resolver ts - platform_api - Visual Studio Code](https://github.com/BeeQuantAI/platform_app/assets/80236130/f6139ee1-b442-483f-a527-192d8d42d90c)
![2024-05-15 06_59_55-user resolver ts - platform_api - Visual Studio Code](https://github.com/BeeQuantAI/platform_app/assets/80236130/42c3eaa7-0dda-4557-bb8d-2cfcfe25f0d8)
![2024-05-15 07_02_48-BeeQuant Platform](https://github.com/BeeQuantAI/platform_app/assets/80236130/d55f5d78-6e63-4f7b-993a-079718bc4fe1)
![2024-05-15 07_03_26-BeeQuant Platform](https://github.com/BeeQuantAI/platform_app/assets/80236130/177caef2-5032-410a-91a3-f7cacc8a1639)
![2024-06-02 13_34_17-BeeQuant Platform](https://github.com/BeeQuantAI/platform_app/assets/80236130/98bbc24e-f645-45e6-860e-78d427596c81)